### PR TITLE
Fixed: Game freezes when playing again after completing the level

### DIFF
--- a/Assets/_Project/Scripts/Core/Backend/Scene Control/LevelSceneController.cs
+++ b/Assets/_Project/Scripts/Core/Backend/Scene Control/LevelSceneController.cs
@@ -47,7 +47,13 @@ namespace _Project.Scripts.Core.Backend.Scene_Control
             else if (Array.TrueForAll(enemies, enemy => enemy.CurrentHealth <= 0)) // Check if all enemies are dead.
                 GameOver(true);
         }
-        
+
+        private void OnDestroy()
+        {
+            // This is to prevent the game from freezing after returning from the menu scene.
+            Time.timeScale = 1f; // Unfreeze the game;
+        }
+
         private void GameOver(bool win)
         {
             Cursor.visible = true; // Show the cursor


### PR DESCRIPTION
The Time.timeScale was being set to 0 and was never being restored to 1

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Fixed: Game freezes when playing again after completing the level
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->

1. Play Assets/_Project/Scenes/Title Scene.unity
2. Press "Play" on the menu
3. Either die or win
4. Go to back to main menu
5. Press "Play" again
6. Your game shouldn't be frozen as before

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/user-attachments/assets/b9ebd2ed-2eb6-4419-8322-9adba42fda0f)
![image](https://github.com/user-attachments/assets/5a4f4ac4-b917-459f-a526-477971f01662)

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
https://timeisup.atlassian.net/browse/SCRUM-81?atlOrigin=eyJpIjoiZjZmNTMyOWRhNmE1NGEzNWI5ZjkyOGZlMTViMDE0MjYiLCJwIjoiaiJ9
## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Sprint 4