### PR TITLE
Added Network Scene Management logic 

### DIFF
--- a/Assets/_Project/Scenes/Test Scenes/Multiplayer UI.unity
+++ b/Assets/_Project/Scenes/Test Scenes/Multiplayer UI.unity
@@ -604,7 +604,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 36677079}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -612,7 +612,7 @@ RectTransform:
   - {fileID: 924737252}
   - {fileID: 2034866623}
   - {fileID: 346214250}
-  m_Father: {fileID: 758052145}
+  m_Father: {fileID: 1979348335}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1020,6 +1020,140 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 68904585}
+  m_CullTransparentMesh: 1
+--- !u!1 &90057909
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 90057910}
+  - component: {fileID: 90057912}
+  - component: {fileID: 90057911}
+  m_Layer: 5
+  m_Name: Label [TMP_Text]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &90057910
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90057909}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1312951008}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -200, y: 405.81372}
+  m_SizeDelta: {x: 400, y: 80}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &90057911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90057909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '# of Players:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &90057912
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 90057909}
   m_CullTransparentMesh: 1
 --- !u!1 &94012209
 GameObject:
@@ -2335,6 +2469,7 @@ GameObject:
   - component: {fileID: 187355744}
   - component: {fileID: 187355743}
   - component: {fileID: 187355742}
+  - component: {fileID: 187355746}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -2433,6 +2568,19 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &187355746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187355741}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0eafff0c36084f4dbbf60d331e8b032, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startingPage: 0
 --- !u!1 &231720491
 GameObject:
   m_ObjectHideFlags: 0
@@ -3074,17 +3222,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 279430112}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1977470370}
-  m_Father: {fileID: 758052145}
+  m_Father: {fileID: 1979348335}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -20, y: 20}
   m_SizeDelta: {x: 256, y: 64}
   m_Pivot: {x: 1, y: 0}
 --- !u!114 &279430114
@@ -8350,6 +8498,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 758052145}
+  - component: {fileID: 758052146}
   m_Layer: 5
   m_Name: Lobby
   m_TagString: Untagged
@@ -8369,9 +8518,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2038433081}
-  - {fileID: 36677080}
-  - {fileID: 279430113}
+  - {fileID: 1979348335}
   m_Father: {fileID: 187355745}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -8379,6 +8526,22 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &758052146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 758052144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3514ac590f6f40f5a339dd3163a2ffeb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameSceneName: Greybox
+  lobbyCodeText: {fileID: 777181444}
+  playerCountText: {fileID: 770383268}
+  continueButton: {fileID: 279430114}
 --- !u!1 &763932821
 GameObject:
   m_ObjectHideFlags: 0
@@ -8500,6 +8663,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 763932821}
   m_CullTransparentMesh: 1
+--- !u!1 &770383266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 770383267}
+  - component: {fileID: 770383269}
+  - component: {fileID: 770383268}
+  m_Layer: 5
+  m_Name: Player Count [TMP_Text]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &770383267
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770383266}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1312951008}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 200, y: 405.81372}
+  m_SizeDelta: {x: 400, y: 80}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &770383268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770383266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: ' 123456'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 48
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &770383269
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 770383266}
+  m_CullTransparentMesh: 1
 --- !u!1 &777181442
 GameObject:
   m_ObjectHideFlags: 0
@@ -8512,7 +8809,7 @@ GameObject:
   - component: {fileID: 777181445}
   - component: {fileID: 777181444}
   m_Layer: 5
-  m_Name: Text (TMP) (1)
+  m_Name: Lobby Code [TMP_Text]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -10425,7 +10722,7 @@ GameObject:
   - component: {fileID: 922647926}
   - component: {fileID: 922647925}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: Label [TMP_Text]
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -10928,8 +11225,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -13976,10 +14273,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 326330360}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1774319535}
+        m_TargetAssemblyTypeName: _Project.Scripts.UI.MainMenu, Assembly-CSharp
+        m_MethodName: OnMultiPlayButtonClicked
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -15777,6 +16074,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1306682704}
   m_CullTransparentMesh: 1
+--- !u!1 &1312951007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1312951008}
+  m_Layer: 5
+  m_Name: Player Info
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1312951008
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1312951007}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 90057910}
+  - {fileID: 770383267}
+  m_Father: {fileID: 1979348335}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -67}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1324936883
 GameObject:
   m_ObjectHideFlags: 0
@@ -22758,8 +23092,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -24089,6 +24423,85 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1979222161}
   m_CullTransparentMesh: 1
+--- !u!1 &1979348334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1979348335}
+  - component: {fileID: 1979348337}
+  - component: {fileID: 1979348336}
+  m_Layer: 5
+  m_Name: Panel [Image]
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1979348335
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979348334}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2038433081}
+  - {fileID: 1312951008}
+  - {fileID: 36677080}
+  - {fileID: 279430113}
+  m_Father: {fileID: 758052145}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1979348336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979348334}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.078431375, b: 0.08627451, a: 0.8}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1979348337
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1979348334}
+  m_CullTransparentMesh: 1
 --- !u!1 &1979563302
 GameObject:
   m_ObjectHideFlags: 0
@@ -25033,14 +25446,14 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2038433080}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 922647924}
   - {fileID: 777181443}
-  m_Father: {fileID: 758052145}
+  m_Father: {fileID: 1979348335}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -25591,8 +26004,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Assets/_Project/Scripts/Core/Backend/BaseSystem.cs
+++ b/Assets/_Project/Scripts/Core/Backend/BaseSystem.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace _Project.Scripts.Core.Backend
 {
@@ -7,6 +8,8 @@ namespace _Project.Scripts.Core.Backend
     /// </summary>
     public abstract class BaseSystem<T> : MonoBehaviour where T : BaseSystem<T>
     {
+        protected abstract bool IsPersistent { get; }
+
         /// <summary>
         /// The instance of the system.
         /// </summary>
@@ -15,15 +18,23 @@ namespace _Project.Scripts.Core.Backend
         protected virtual void Awake()
         {
             // If there is already an instance of the system, destroy the new one.
-            if (Instance)
+            if (Instance && Instance != this)
             {
-                DestroyImmediate(gameObject);
+                Destroy(gameObject);
                 return;
             }
-            
+
             // If not, set the instance to this system and make it persistent between scenes.
             Instance = this as T;
-            DontDestroyOnLoad(gameObject);
+            if (IsPersistent)
+                DontDestroyOnLoad(gameObject);
+        }
+
+        private void OnDestroy()
+        {
+            // If instance is being destroyed set Instance property to null.
+            if (Instance == this)
+                Instance = null;
         }
     }
 }

--- a/Assets/_Project/Scripts/Core/Backend/Scene Control/SceneSystem.cs
+++ b/Assets/_Project/Scripts/Core/Backend/Scene Control/SceneSystem.cs
@@ -94,7 +94,7 @@ namespace _Project.Scripts.Core.Backend.Scene_Control
             // Load the requested scene. If the scene is not found, log an error and return.
             sceneOp = NetworkSystem.Instance.Runner.LoadScene(request.SceneName, request.Mode);
 
-            if (sceneOp.IsValid)
+            if (!sceneOp.IsValid)
             {
                 Debug.LogError($"Failed to load scene {request.SceneName}");
                 return;

--- a/Assets/_Project/Scripts/Core/Backend/Scene Control/SceneSystem.cs
+++ b/Assets/_Project/Scripts/Core/Backend/Scene Control/SceneSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using Fusion;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -9,6 +10,9 @@ namespace _Project.Scripts.Core.Backend.Scene_Control
     /// </summary>
     public class SceneSystem : BaseSystem<SceneSystem>
     {
+        protected override bool IsPersistent => true;
+        internal NetworkSceneManagerDefault NetworkSceneManager { get; private set; }
+
         /// <summary>
         /// Name of the loading scene.
         /// </summary>
@@ -18,6 +22,16 @@ namespace _Project.Scripts.Core.Backend.Scene_Control
         /// Coroutine for loading a scene.
         /// </summary>
         private Coroutine _loadSceneCoroutine;
+
+        protected override void Awake()
+        {
+            base.Awake();
+
+            // Create a new gameobject for the network scene manager.
+            var sceneManagerGameobject = new GameObject("Network Scene Manager");
+            sceneManagerGameobject.transform.SetParent(transform);
+            NetworkSceneManager = sceneManagerGameobject.AddComponent<NetworkSceneManagerDefault>();
+        }
 
         /// <summary>
         /// Load a scene.
@@ -55,6 +69,39 @@ namespace _Project.Scripts.Core.Backend.Scene_Control
 
             // Else, wait until the requested scene is loaded.
             yield return sceneOp;
+        }
+
+        /// <summary>
+        /// Coroutine for loading a scene.
+        /// </summary>
+        /// <param name="request">struct describing scene detail to be loaded</param>
+        public async void LoadNetworkScene(SceneLoadRequest request)
+        {
+            if (!NetworkSystem.Instance.Runner)
+            {
+                Debug.LogError("Trying to load a scene without a runner");
+                return;
+            }
+
+            // If the current scene is not the authority, return.
+            if (!NetworkSystem.Instance.Runner.IsSceneAuthority)
+                return;
+
+            // Load the loading scene first.
+            var sceneOp = NetworkSystem.Instance.Runner.LoadScene(loadingSceneName, LoadSceneMode.Additive);
+            await sceneOp;
+
+            // Load the requested scene. If the scene is not found, log an error and return.
+            sceneOp = NetworkSystem.Instance.Runner.LoadScene(request.SceneName, request.Mode);
+
+            if (sceneOp.IsValid)
+            {
+                Debug.LogError($"Failed to load scene {request.SceneName}");
+                return;
+            }
+
+            // Else, wait until the requested scene is loaded.
+            await sceneOp;
         }
     }
 }

--- a/Assets/_Project/Scripts/UI/LobbyPage.cs
+++ b/Assets/_Project/Scripts/UI/LobbyPage.cs
@@ -1,0 +1,47 @@
+﻿using _Project.Scripts.Core.Backend;
+using _Project.Scripts.Core.Backend.Scene_Control;
+using TMPro;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace _Project.Scripts.UI
+{
+    public class LobbyPage : UIPage
+    {
+        public override PageID ID => PageID.LobbyPage;
+
+        [SerializeField] private string gameSceneName;
+        [SerializeField] private TMP_Text lobbyCodeText;
+        [SerializeField] private TMP_Text playerCountText;
+        [SerializeField] private Button continueButton;
+
+        private void OnEnable()
+        {
+            // Set the lobby code text to the current session name
+            lobbyCodeText.text = NetworkSystem.Instance.CurrentSessionInfo.Name;
+
+            // Set the continue button interactable based on whether the player has scene authority
+            continueButton.interactable = NetworkSystem.Instance.IsSceneAuthority;
+            continueButton.onClick.AddListener(OnContinueButtonClicked);
+        }
+
+        private void OnDisable()
+        {
+            // Remove the listener from the continue button
+            continueButton.onClick.RemoveListener(OnContinueButtonClicked);
+        }
+
+        private void OnContinueButtonClicked()
+        {
+            // Load the game scene
+            SceneSystem.Instance.LoadNetworkScene(new SceneLoadRequest(gameSceneName, LoadSceneMode.Single));
+        }
+
+        private void Update()
+        {
+            // Update the player count text
+            playerCountText.text = NetworkSystem.Instance.CurrentSessionInfo.PlayerCount.ToString();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/UI/LobbyPage.cs.meta
+++ b/Assets/_Project/Scripts/UI/LobbyPage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3514ac590f6f40f5a339dd3163a2ffeb
+timeCreated: 1731004255

--- a/Assets/_Project/Scripts/UI/MainMenu.cs
+++ b/Assets/_Project/Scripts/UI/MainMenu.cs
@@ -6,12 +6,20 @@ namespace _Project.Scripts.UI
 {
     public class MainMenu : UIPage
     {
+        public override PageID ID => PageID.MainMenu;
+
         [SerializeField] private string gameSceneName;
-        
+
         public void OnStartButtonClicked()
         {
             SceneSystem.Instance.LoadScene(new SceneLoadRequest(gameSceneName, LoadSceneMode.Single));
         }
+
+        public void OnMultiPlayButtonClicked()
+        {
+            UIManager.Instance.SwitchPage(PageID.SessionsPage);
+        }
+
         /// <summary>
         /// Called when the quit button is clicked
         /// </summary>
@@ -21,4 +29,3 @@ namespace _Project.Scripts.UI
         }
     }
 }
-    

--- a/Assets/_Project/Scripts/UI/PageID.cs
+++ b/Assets/_Project/Scripts/UI/PageID.cs
@@ -1,0 +1,9 @@
+﻿namespace _Project.Scripts.UI
+{
+    public enum PageID
+    {
+        MainMenu,
+        SessionsPage,
+        LobbyPage
+    }
+}

--- a/Assets/_Project/Scripts/UI/PageID.cs.meta
+++ b/Assets/_Project/Scripts/UI/PageID.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 66697c0c29b34975b93cb0a195f8b695
+timeCreated: 1731042553

--- a/Assets/_Project/Scripts/UI/SessionPage.cs
+++ b/Assets/_Project/Scripts/UI/SessionPage.cs
@@ -6,6 +6,8 @@ namespace _Project.Scripts.UI
 {
     public class SessionPage : UIPage
     {
+        public override PageID ID => PageID.SessionsPage;
+
         [SerializeField] private TMP_Text lobbyCodeText;
         [SerializeField] private TMP_InputField lobbyCodeInputField;
         [SerializeField] private TMP_Text statusText;
@@ -13,30 +15,39 @@ namespace _Project.Scripts.UI
         public async void OnCreateButtonClicked()
         {
             // Start the game in host mode
-            var partyCode = await NetworkSystem.Instance.CreateSession();
-            lobbyCodeText.text = partyCode;
+            var status = await NetworkSystem.Instance.CreateSession();
+
+            UpdateStatus(lobbyCodeText, status.Item1, status.Item2);
         }
 
         public async void OnJoinButtonClicked()
         {
-            if (string.IsNullOrEmpty(lobbyCodeInputField.text) || lobbyCodeInputField.text.Length <= 4)
+            var statusFlag = false;
+            var message = "Invalid lobby code";
+
+            if (!string.IsNullOrEmpty(lobbyCodeInputField.text) && lobbyCodeInputField.text.Length > 4)
             {
-                statusText.text = "Invalid lobby code";
-                statusText.color = Color.red;
-                
-                return;
+                // Start the game in client mode
+                var status = await NetworkSystem.Instance.JoinSession(lobbyCodeInputField.text);
+
+                statusFlag = status.Item1;
+                message = status.Item2;
             }
-            // Start the game in client mode
-            var status = await NetworkSystem.Instance.JoinSession(lobbyCodeInputField.text);
-            if (status.Item1)
+
+            UpdateStatus(statusText, statusFlag, message);
+        }
+
+        private void UpdateStatus(TMP_Text statusTextField, bool status, string message)
+        {
+            statusTextField.text = message;
+            if (status)
             {
-                statusText.text = status.Item2;
-                statusText.color = Color.green;
+                statusTextField.color = Color.green;
+                UIManager.Instance.SwitchPage(PageID.LobbyPage);
             }
             else
             {
-                statusText.text = status.Item2;
-                statusText.color = Color.red;
+                statusTextField.color = Color.red;
             }
         }
     }

--- a/Assets/_Project/Scripts/UI/UIManager.cs
+++ b/Assets/_Project/Scripts/UI/UIManager.cs
@@ -1,56 +1,59 @@
 using System.Collections.Generic;
+using _Project.Scripts.Core.Backend;
 using UnityEngine;
 
 namespace _Project.Scripts.UI
 {
-    public class UIManager : MonoBehaviour
+    public class UIManager : BaseSystem<UIManager>
     {
+        protected override bool IsPersistent => false;
+        [SerializeField] private PageID startingPage = PageID.MainMenu;
+
         // Dictionary to store all UI pages
-        private Dictionary<string, UIPage> _pages;
-   
+        private Dictionary<PageID, UIPage> _pages;
+
         // Reference to the current page
         private UIPage _currentPage;
-   
+
         private void Start()
         {
             // Initialize the dictionary
-            _pages = new Dictionary<string, UIPage>();
-   
+            _pages = new Dictionary<PageID, UIPage>();
+
             // Find all UI pages in the scene
-            UIPage[] allPages = FindObjectsOfType<UIPage>();
-            foreach (UIPage page in allPages)
+            var allPages = FindObjectsOfType<UIPage>(true);
+            foreach (var page in allPages)
             {
                 page.Initialize();
-                _pages.Add(page.name, page);  // Add the page to the dictionary
-                page.Hide();  // Hide the page
+                _pages.Add(page.ID, page); // Add the page to the dictionary
+                if (page.ID == startingPage)
+                    continue;
+
+                page.Hide(); // Hide the page
+                _currentPage = page;
             }
         }
+
         // Method to switch between pages
-        public void SwitchPage(string pageName)
+        public void SwitchPage(PageID id)
         {
-            if (_currentPage != null)
+            if (!_pages.TryGetValue(id, out var page))
             {
-                _currentPage.Hide();
+                Debug.LogError($"UI Page {id} not found!");
+                return;
             }
-            if (_pages.ContainsKey(pageName))
-            {
-                _currentPage = _pages[pageName];
-                _currentPage.Show();
-            }
-            else
-            {
-                Debug.LogWarning($"UI Page {pageName} not found!");
-            }
+
+            if (_currentPage.ID != startingPage)
+                _currentPage?.Hide();
+
+            _currentPage = page;
+            _currentPage.Show();
         }
-   
+
         // Update method to update the current page
         private void Update()
         {
-            if (_currentPage != null)
-            {
-                _currentPage.UpdatePage();
-            }
+            _currentPage?.UpdatePage();
         }
     }
 }
-

--- a/Assets/_Project/Scripts/UI/UIPage.cs
+++ b/Assets/_Project/Scripts/UI/UIPage.cs
@@ -4,6 +4,7 @@ namespace _Project.Scripts.UI
 {
     public abstract class UIPage : MonoBehaviour
     {
+        public abstract PageID ID { get; }
         // Flag to check if the page is active
         private bool _isActive;
 


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Loading a scene over network
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
ParelSync

1. Open the ParelSync>Clone Manager
2. Create a new clone by clicking the "Add new clone" button in the clone manager window
3. Then click on the "Open in New Editor" button, this will open a clone of your current unity project (DO NOT CHANGE ANYTHING ON THE CLONE)

Playing

1. Play scene Assets/_Project/Scenes/Test Scenes/Multiplayer UI.unity on both the editor windows.
2. Select the "Multi-Play" option on both editors.
3. Press Create on one editor window, copy the code on the screen
4. Paste the code in the "Enter Party Code" input field and press join
5. You'll see the lobby page if the connection is successful. (img 1)
6. The "Continue" button should only be active on the host client.
7. Clicking the "Continue" button on the host client will load the "Greybox" scene on both the editors.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/user-attachments/assets/a77fd18a-c6c0-45ad-8cc1-23a7c5c428d5)

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
[Players should load the same level](https://timeisup.atlassian.net/browse/SCRUM-95?atlOrigin=eyJpIjoiZjViYWQyNGMxMGFhNDU1OWI1MzczOWZhMTkxN2I0YzYiLCJwIjoiaiJ9)
## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Sprint 4