### PR TITLE
TSM not working

### DIFF
--- a/Assets/_Project/Scripts/Core/Backend/LootSpawner.cs
+++ b/Assets/_Project/Scripts/Core/Backend/LootSpawner.cs
@@ -1,8 +1,10 @@
 using System;
 using _Project.Scripts.Core.Backend.Ability;
+using _Project.Scripts.Core.Backend.Scene_Control;
+using _Project.Scripts.Core.Player_Controllers;
+using _Project.Scripts.Core.Weapons;
 using _Project.Scripts.Core.Weapons.Abilities;
 using UnityEngine;
-using Object = UnityEngine.Object;
 using Random = UnityEngine.Random;
 
 namespace _Project.Scripts.Core.Backend
@@ -11,28 +13,36 @@ namespace _Project.Scripts.Core.Backend
     {
         [SerializeField] private GameObject[] lootPrefabs;
 
-        /// <summary>
-        /// Singleton instance of LootSpawner.
-        /// </summary>
-        private void Awake()
+        private void OnEnable()
         {
-            if (Instance && Instance != this)
-            {
-                Destroy(gameObject);
-                return;
-            }
-
-            Instance = this;
+            PlayerController.OnDeath += OnPlayerDeath;
+        }
+        
+        private void OnDisable()
+        {
+            PlayerController.OnDeath -= OnPlayerDeath;
         }
 
-        public static LootSpawner Instance { get; private set; }
+        /// <summary>
+        /// Function to spawn loot on Player Death.
+        /// </summary>
+        /// <param name="killingplayer"></param>
+        /// <param name="playerkilled"></param>
+        /// <param name="weaponkilledby"></param>
+        private void OnPlayerDeath(PlayerController killingplayer, PlayerController playerkilled, Weapon weaponkilledby)
+        {
+            if (killingplayer != LevelSceneController.Instance.Player)
+                return;
+            
+            DropLoot(playerkilled.transform.position);
+        }
 
         /// <summary>
         /// Function to spawn loot on Enemy Death.
         /// </summary>
         /// <param name="lootDropPosition"></param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public void LootDrop(Vector3 lootDropPosition)
+        private void DropLoot(Vector3 lootDropPosition)
         {
             var dropType = Random.Range(0, 2);
             switch (dropType)

--- a/Assets/_Project/Scripts/Core/Enemy/EnemyController.cs
+++ b/Assets/_Project/Scripts/Core/Enemy/EnemyController.cs
@@ -61,9 +61,6 @@ namespace _Project.Scripts.Core.Enemy
         {
             gameObject.SetActive(false);
             base.Die(enemyPlayer, weaponKilledBy);
-            
-            // Spawn loot
-            LootSpawner.Instance.LootDrop(_enemyInputController.Enemy.transform.position);
         }
     }
 }

--- a/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
@@ -16,7 +16,7 @@ namespace _Project.Scripts.Core.Player_Controllers
     {
         public delegate void PlayerDeath(PlayerController killingPlayer, PlayerController playerKilled, Weapon weaponKilledBy);
 
-        public event PlayerDeath OnDeath;
+        public static event PlayerDeath OnDeath;
 
         /// <summary>
         /// Component that handles movement.

--- a/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using _Project.Scripts.Core.Backend.Interfaces;
+﻿using _Project.Scripts.Core.Backend.Interfaces;
 using _Project.Scripts.Core.Character;
 using _Project.Scripts.Core.Character.Weapon_Controller;
 using _Project.Scripts.Core.Weapons;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace _Project.Scripts.Core.Player_Controllers
 {

--- a/Assets/_Project/Scripts/Gameplay/PCG/EnemyDeathListener.cs
+++ b/Assets/_Project/Scripts/Gameplay/PCG/EnemyDeathListener.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace _Project.Scripts.Gameplay.PCG
 {
     /// <summary>
-    /// Listens for enemy deaths and invokes an event when all enemies are dead.
+    /// Listens for enemy deaths under a game object and invokes an event when all enemies are dead.
     /// </summary>
     public class EnemyDeathListener
     {
@@ -33,17 +33,22 @@ namespace _Project.Scripts.Gameplay.PCG
                 Debug.LogError("No enemies found in the parent object");
                 return;
             }
+            
+            PlayerController.OnDeath += OnEnemyDeath;
+        }
 
-            // Subscribe to the OnDeath event of each enemy
-            foreach (var enemy in _enemies)
-                enemy.OnDeath += OnEnemyDeath;
+        ~EnemyDeathListener()
+        {
+            PlayerController.OnDeath -= OnEnemyDeath;
         }
 
         private void OnEnemyDeath(PlayerController killingPlayer, PlayerController playerKilled, Weapon weaponKilledBy)
         {
+            if(!_enemies.Contains(playerKilled))
+                return;
+
             // Remove the enemy from the list and unsubscribe from the event
             _enemies.Remove((EnemyController)playerKilled);
-            playerKilled.OnDeath -= OnEnemyDeath;
 
             // If there are no enemies left, invoke the event
             if (_enemies.Count == 0)

--- a/Assets/_Project/Scripts/Gameplay/Time Stability Meter/TimeStabilityMeter.cs
+++ b/Assets/_Project/Scripts/Gameplay/Time Stability Meter/TimeStabilityMeter.cs
@@ -28,15 +28,17 @@ namespace _Project.Scripts.Gameplay.Time_Stability_Meter
             TimeStability = initialTimeStability;
         }
 
-        private void Start()
+        private void OnEnable()
         {
-            foreach (var enemy in LevelSceneController.Instance.enemies)
-            {
-                enemy.OnDeath += OnEnemyDeath;
-            }
+            PlayerController.OnDeath += OnPlayerDeath;
+        }
+        
+        private void OnDisable()
+        {
+            PlayerController.OnDeath -= OnPlayerDeath;
         }
 
-        private void OnEnemyDeath(PlayerController killingPlayer, PlayerController playerKilled, Weapon weaponKilledBy)
+        private void OnPlayerDeath(PlayerController killingPlayer, PlayerController playerKilled, Weapon weaponKilledBy)
         {
             if(killingPlayer != LevelSceneController.Instance.Player)
                 return;


### PR DESCRIPTION
https://timeisup.atlassian.net/browse/SCRUM-170

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
The issue was the execution order of the script DungeonGeneraator, which populates the enemies list in LevelSceneController, and the TimeStabilityMeter, which refers to this list and subscribes to all enemy death events. This happens because both logic is written in the Start function, which sometimes calls DungeonGenerator.Start() before TSM.Start(), which is ideal, but when the opposite happens, the code silently breaks.
Fix: the OnDeath event is now static (observer pattern) which makes looking for the enemies list unnecessary.
## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
1. Test everything from TSM, Death drop and Wave spawner (as all of these used the OnDeath event).
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/user-attachments/assets/36a22bb7-0776-4606-8936-e53152bb34c3)
![image](https://github.com/user-attachments/assets/e978af93-3f52-4dde-88e2-b9e40a09fdb9)
![image](https://github.com/user-attachments/assets/7639dbe6-c874-472b-9c0a-e0563beec234)
![image](https://github.com/user-attachments/assets/d3fc9aa2-e2e3-4ea4-9682-56822c0a74f2)

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
https://timeisup.atlassian.net/browse/SCRUM-170
## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Sprint 8