### PR TITLE
updated scroll sensitivity and added hotkeys to switch weapons

### DIFF
--- a/Assets/_Project/Scripts/Core/Character/Hand Controller/HandController.cs
+++ b/Assets/_Project/Scripts/Core/Character/Hand Controller/HandController.cs
@@ -207,6 +207,29 @@ namespace _Project.Scripts.Core.Character.Hand_Controller
 
             CurrentItem = weapons[_currentWeaponIndex];
         }
+        
+        /// <summary>
+        /// Switches the weapon by a delta value.
+        /// </summary>
+        /// <param name="slotIndex">The value with which the weapon switches</param>
+        public void SwitchWeaponUsingHotkey(int slotIndex)
+        {
+            if (slotIndex < 0 || slotIndex >= weapons.Length)
+            {
+                Debug.LogWarning($"Invalid slot index {slotIndex}.");
+                return;
+            }
+
+            if (_currentWeaponIndex == slotIndex)
+            {
+                Debug.Log($"Already using weapon in slot {slotIndex}");
+                return;
+            }
+
+            _currentWeaponIndex = slotIndex;
+            CurrentItem = weapons[_currentWeaponIndex];
+            Debug.Log($"[Hotkey] Switched to weapon slot: {_currentWeaponIndex}");
+        }
 
         /// <summary>
         /// Equips the current ability and starts the weapon switch coroutine.

--- a/Assets/_Project/Scripts/Core/Character/PlayerInput.cs
+++ b/Assets/_Project/Scripts/Core/Character/PlayerInput.cs
@@ -89,6 +89,15 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""Switch Weapon Hotkey"",
+                    ""type"": ""Button"",
+                    ""id"": ""d96aba67-486e-449a-ba2a-222ddbc75c58"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -212,6 +221,39 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
                     ""action"": ""Loot Pick Up"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""1c05b5a4-3700-4ddd-94f7-6b06c689c959"",
+                    ""path"": ""<Keyboard>/1"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Switch Weapon Hotkey"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""93825cba-c118-4061-85c1-bbcfbeefa006"",
+                    ""path"": ""<Keyboard>/2"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Switch Weapon Hotkey"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""f623737f-4845-41f7-b51e-3a01ac65b76d"",
+                    ""path"": ""<Keyboard>/3"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Switch Weapon Hotkey"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         }
@@ -238,6 +280,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         m_PlayerControl_SwitchWeapon = m_PlayerControl.FindAction("Switch Weapon", throwIfNotFound: true);
         m_PlayerControl_Reload = m_PlayerControl.FindAction("Reload", throwIfNotFound: true);
         m_PlayerControl_LootPickUp = m_PlayerControl.FindAction("Loot Pick Up", throwIfNotFound: true);
+        m_PlayerControl_SwitchWeaponHotkey = m_PlayerControl.FindAction("Switch Weapon Hotkey", throwIfNotFound: true);
     }
 
     public void Dispose()
@@ -306,6 +349,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
     private readonly InputAction m_PlayerControl_SwitchWeapon;
     private readonly InputAction m_PlayerControl_Reload;
     private readonly InputAction m_PlayerControl_LootPickUp;
+    private readonly InputAction m_PlayerControl_SwitchWeaponHotkey;
     public struct PlayerControlActions
     {
         private @PlayerInput m_Wrapper;
@@ -317,6 +361,7 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         public InputAction @SwitchWeapon => m_Wrapper.m_PlayerControl_SwitchWeapon;
         public InputAction @Reload => m_Wrapper.m_PlayerControl_Reload;
         public InputAction @LootPickUp => m_Wrapper.m_PlayerControl_LootPickUp;
+        public InputAction @SwitchWeaponHotkey => m_Wrapper.m_PlayerControl_SwitchWeaponHotkey;
         public InputActionMap Get() { return m_Wrapper.m_PlayerControl; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -347,6 +392,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @LootPickUp.started += instance.OnLootPickUp;
             @LootPickUp.performed += instance.OnLootPickUp;
             @LootPickUp.canceled += instance.OnLootPickUp;
+            @SwitchWeaponHotkey.started += instance.OnSwitchWeaponHotkey;
+            @SwitchWeaponHotkey.performed += instance.OnSwitchWeaponHotkey;
+            @SwitchWeaponHotkey.canceled += instance.OnSwitchWeaponHotkey;
         }
 
         private void UnregisterCallbacks(IPlayerControlActions instance)
@@ -372,6 +420,9 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
             @LootPickUp.started -= instance.OnLootPickUp;
             @LootPickUp.performed -= instance.OnLootPickUp;
             @LootPickUp.canceled -= instance.OnLootPickUp;
+            @SwitchWeaponHotkey.started -= instance.OnSwitchWeaponHotkey;
+            @SwitchWeaponHotkey.performed -= instance.OnSwitchWeaponHotkey;
+            @SwitchWeaponHotkey.canceled -= instance.OnSwitchWeaponHotkey;
         }
 
         public void RemoveCallbacks(IPlayerControlActions instance)
@@ -416,5 +467,6 @@ public partial class @PlayerInput: IInputActionCollection2, IDisposable
         void OnSwitchWeapon(InputAction.CallbackContext context);
         void OnReload(InputAction.CallbackContext context);
         void OnLootPickUp(InputAction.CallbackContext context);
+        void OnSwitchWeaponHotkey(InputAction.CallbackContext context);
     }
 }

--- a/Assets/_Project/Scripts/Core/Character/PlayerInput.inputactions
+++ b/Assets/_Project/Scripts/Core/Character/PlayerInput.inputactions
@@ -67,6 +67,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Switch Weapon Hotkey",
+                    "type": "Button",
+                    "id": "d96aba67-486e-449a-ba2a-222ddbc75c58",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -188,6 +197,39 @@
                     "processors": "",
                     "groups": "",
                     "action": "Loot Pick Up",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1c05b5a4-3700-4ddd-94f7-6b06c689c959",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Switch Weapon Hotkey",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "93825cba-c118-4061-85c1-bbcfbeefa006",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Switch Weapon Hotkey",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f623737f-4845-41f7-b51e-3a01ac65b76d",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Switch Weapon Hotkey",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/InputController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/InputController.cs
@@ -11,6 +11,7 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
         public virtual event Action OnReloadInput;
         public virtual event Action OnAbilityEquipped;
         public virtual event Action<int> OnSwitchWeaponInput;
+        public virtual event Action<int> OnSwitchWeaponHotkey;
         public virtual event Action OnLootPickupInput;
     }
 }

--- a/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/LocalInputController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/LocalInputController.cs
@@ -41,6 +41,8 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
         
         [SerializeField] private float scrollCooldown = 0.25f; // Cooldown for weapon switching
         private float _lastScrollTime;
+        public override event Action<int> OnSwitchWeaponHotkey;
+
 
         public override event Action OnReloadInput;
 
@@ -76,6 +78,7 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
             _playerInput.PlayerControl.EquipAbility.performed += OnEquipAbilityInput;
 
             _playerInput.PlayerControl.SwitchWeapon.performed += OnSwitchWeaponInputReceived;
+            _playerInput.PlayerControl.SwitchWeaponHotkey.performed += OnSwitchWeaponHotkeyInput;
             
             _playerInput.PlayerControl.Reload.performed += OnReloadInputReceived;
             
@@ -108,6 +111,7 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
             _playerInput.PlayerControl.EquipAbility.performed -= OnEquipAbilityInput;
 
             _playerInput.PlayerControl.SwitchWeapon.performed -= OnSwitchWeaponInputReceived;
+            _playerInput.PlayerControl.SwitchWeaponHotkey.performed -= OnSwitchWeaponHotkeyInput;
             
             _playerInput.PlayerControl.Reload.performed -= OnReloadInputReceived;
             
@@ -214,10 +218,26 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
             float scrollY = context.ReadValue<float>();
             if (Mathf.Abs(scrollY) > 0.01f)
             {
-                int direction = scrollY > 0 ? 1 : -1;
+                int direction = scrollY > 0 ? -1 : 1;
                 OnSwitchWeaponInput?.Invoke(direction);
                 _lastScrollTime = Time.time;
             }
+        }
+        
+        private void OnSwitchWeaponHotkeyInput(InputAction.CallbackContext context)
+        {
+            string key = context.control.displayName;
+
+            int slotIndex = key switch
+            {
+                "1" => 0,
+                "2" => 1,
+                "3" => 2,
+                _ => -1
+            };
+
+            if (slotIndex >= 0)
+                OnSwitchWeaponHotkey?.Invoke(slotIndex);
         }
 
         #endregion

--- a/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/LocalInputController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/Input Controllers/LocalInputController.cs
@@ -38,6 +38,9 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
         /// Event that is called when the player switches weapons.
         /// </summary>
         public override event Action<int> OnSwitchWeaponInput;
+        
+        [SerializeField] private float scrollCooldown = 0.25f; // Cooldown for weapon switching
+        private float _lastScrollTime;
 
         public override event Action OnReloadInput;
 
@@ -205,8 +208,16 @@ namespace _Project.Scripts.Core.Player_Controllers.Input_Controllers
         /// <param name="context">input callback context</param>
         private void OnSwitchWeaponInputReceived(InputAction.CallbackContext context)
         {
-            // Invoke the OnSwitchWeaponInput event.
-            OnSwitchWeaponInput?.Invoke((int)context.ReadValue<float>());
+            // Prevents firing too often
+            if (Time.time - _lastScrollTime < scrollCooldown) return;
+
+            float scrollY = context.ReadValue<float>();
+            if (Mathf.Abs(scrollY) > 0.01f)
+            {
+                int direction = scrollY > 0 ? 1 : -1;
+                OnSwitchWeaponInput?.Invoke(direction);
+                _lastScrollTime = Time.time;
+            }
         }
 
         #endregion

--- a/Assets/_Project/Scripts/Core/Player Controllers/LocalPlayerController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/LocalPlayerController.cs
@@ -102,6 +102,8 @@ namespace _Project.Scripts.Core.Player_Controllers
             _localInputController.OnAbilityEquipped += AbilityEquipped;
 
             _localInputController.OnSwitchWeaponInput += SwitchWeapon;
+            _localInputController.OnSwitchWeaponHotkey += SwitchWeaponHotKey;
+            
             _localInputController.OnReloadInput += Reload;
 
             _localInputController.OnLootPickupInput += PickUpItem;

--- a/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
+++ b/Assets/_Project/Scripts/Core/Player Controllers/PlayerController.cs
@@ -121,6 +121,15 @@ namespace _Project.Scripts.Core.Player_Controllers
         {
             HandController.SwitchWeapon(direction);
         }
+        
+        /// <summary>
+        /// Switch the player's weapon using Hotkey.
+        /// </summary>
+        /// <param name="slot">the number by which the weapon is supposed to switch</param>
+        protected virtual void SwitchWeaponHotKey(int slot)
+        {
+            HandController.SwitchWeaponUsingHotkey(slot);
+        }
 
         protected virtual void Reload()
         {


### PR DESCRIPTION
Weapon Switching!!

<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
Original template by Rob Reddick
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Adjusted Scroll Sensitivity to be a little slower for smoother weapon switching
Added Hotkey [1,2,3] to switch weapons.

## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
**Check if the scrolling seems evident and it makes it easier to switch weapons now than before. Pls try to compare the switching from current version of the game against this PR before approving this.** 
Press 1 to switch to Primary Weapon
Press 2 to switch to Secondary Weapon 
Press 3 to switch to Melee Weapon
Check if pressing the appropriate key takes to the desired weapon.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
https://timeisup.atlassian.net/browse/SCRUM-207
https://timeisup.atlassian.net/browse/SCRUM-198

## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Sprint 12
